### PR TITLE
(c *APIClient) callAPI(request *http.Request) returns the error befor…

### DIFF
--- a/client.go
+++ b/client.go
@@ -260,10 +260,10 @@ func (c *APIClient) callAPI(request *http.Request) (*APIResponse, error) {
 	}
 
 	resp, err := c.cfg.HTTPClient.Do(request)
-	response := NewAPIResponse(resp)
 	if err != nil {
-		return response, err
+		return nil, err
 	}
+	response := NewAPIResponse(resp)
 
 	if c.cfg.Debug {
 		dump, err := httputil.DumpResponse(resp, true)


### PR DESCRIPTION
…e producing an invalid APIResponse

It happens to me that (using phrase-cli) phrase push invocations may timeout. With this change, the timeout err is considered before the nil response is used to create a new APIResponse, that cause a SIGSEGV like

`[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x14062fa]

goroutine 1 [running]:
github.com/phrase/phrase-go.(*APIResponse).populatePageValues(0xc000411950)
	/go/pkg/mod/github.com/phrase/phrase-go@v1.0.18/response.go:82 +0x3a
github.com/phrase/phrase-go.NewAPIResponse(0x0, 0xc000615d00)
	/go/pkg/mod/github.com/phrase/phrase-go@v1.0.18/response.go:142 +0x59
github.com/phrase/phrase-go.(*APIClient).callAPI(0xc00021ec60, 0xc000615d00, 0xc0000d2180, 0xc000664c80, 0x4b)
	/go/pkg/mod/github.com/phrase/phrase-go@v1.0.18/client.go:260 +0x77
github.com/phrase/phrase-go.(*UploadsApiService).UploadCreate(0xc00021ec68, 0x181f4c0, 0xc0000d2180, 0xc00029c2a0, 0x20, 0xc00033b3f8, 0x0, 0x0, 0x0, 0x0, ...)
	/go/pkg/mod/github.com/phrase/phrase-go@v1.0.18/api_uploads.go:184 +0xb1a
github.com/phrase/phrase-cli/cmd/internal.(*Source).uploadFile(0xc0002de100, 0xc00021ec60, 0xc00019af50, 0x0, 0x0, 0x1, 0x1, 0x53)
	/go/src/github.com/phrase/phrase-cli/cmd/internal/push_source.go:189 +0x22c
github.com/phrase/phrase-cli/cmd/internal.(*Source).Push(0xc0002de100, 0xc00021ec60, 0xc00033b800, 0x0, 0x0, 0x0, 0x0)
	/go/src/github.com/phrase/phrase-cli/cmd/internal/push.go:162 +0x36c
github.com/phrase/phrase-cli/cmd/internal.(*PushCommand).Run(0xc0000e0000, 0x171fe76, 0x15)
	/go/src/github.com/phrase/phrase-cli/cmd/internal/push.go:132 +0x77a
github.com/phrase/phrase-cli/cmd.initPush.func1(0xc00028f600, 0x1c14760, 0x0, 0x0)
	/go/src/github.com/phrase/phrase-cli/cmd/push.go:26 +0x19b
github.com/spf13/cobra.(*Command).execute(0xc00028f600, 0x1c14760, 0x0, 0x0, 0xc00028f600, 0x1c14760)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:846 +0x29d
github.com/spf13/cobra.(*Command).ExecuteC(0x1be00e0, 0x0, 0x0, 0x0)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:950 +0x349
github.com/spf13/cobra.(*Command).Execute(...)
	/go/pkg/mod/github.com/spf13/cobra@v1.0.0/command.go:887
github.com/phrase/phrase-cli/cmd.Execute()
	/go/src/github.com/phrase/phrase-cli/cmd/root.go:64 +0x2d
main.main()
	/go/src/github.com/phrase/phrase-cli/main.go:8 +0x20`